### PR TITLE
Even better regexp

### DIFF
--- a/src/lib/css-parse.html
+++ b/src/lib/css-parse.html
@@ -171,7 +171,7 @@ Polymer.CssParse = (function() {
     _rx: {
       comments: /\/\*[^*]*\*+([^/*][^*]*\*+)*\//gim,
       port: /@import[^;]*;/gim,
-      customProp: /(?:^[^;-]+)?--[^;{]*?:[^{};]*?(?:[;\n]|$)/gim,
+      customProp: /(?:^[^;\-\s}]+)?--[^;{]*?:[^{};]*?(?:[;\n]|$)/gim,
       mixinProp: /(?:^|[\s;])?--[^;{]*?:[^{;]*?{[^}]*?}(?:[;\n]|$)?/gim,
       mixinApply: /@apply[\s]*\([^)]*?\)[\s]*(?:[;\n]|$)?/gim,
       varApply: /[^;:]*?:[^;]*?var\([^;]*\)(?:[;\n]|$)?/gim,


### PR DESCRIPTION
Smalled diff comparing to old one and doesn't capture unnecessary spaces and braces.
Check it with such text:

``` css
child-of-child-with-var {
          --variable-own-line: "Varela font";
          margin-top: var(--variable-property-own-line);
          margin-bottom: var(--variable-property-preceded-property);
          --variable-between-properties: 6px;
          background-color: var(--variable-property-before-property); padding-top: var(--variable-property-after-property);
          --variable-assignment-before-property: 7px; padding-bottom: var(--variable-property-after-assignment);
          padding-left: var(--variable-property-before-assignment);--variable-assignment-after-property: 8px;
          top: 12px;--variable-from-other-variable: var(--variable-into-first-variable);--variable-from-another-variable: var(--variable-into-second-variable); --variable-from-last-variable: var(--variable-into-third-variable);
        }

--variable-into-first-variable: 9px;
--variable-into-second-variable: 10px;
--variable-into-third-variable: 11px;


x--color: red;
```
